### PR TITLE
Allow specificying extensions to exclude

### DIFF
--- a/src/main/java/com/samaxes/filter/util/CacheConfigParameter.java
+++ b/src/main/java/com/samaxes/filter/util/CacheConfigParameter.java
@@ -42,7 +42,14 @@ public enum CacheConfigParameter {
      * Cache directive to instructs proxies to cache different versions of the same resource based on specific
      * request-header fields.
      */
-    VARY("vary");
+    VARY("vary"),
+    /**
+     * Cache directive to define any file extensions that should be ignored. Expect a space delimited list.
+     *
+     * Example: .html .map .xyz
+     */
+    EXCLUDE_EXTENSIONS("exclude-extensions"),
+    ;
 
     private final String name;
 


### PR DESCRIPTION
I want to apply this filter to a subfolder (like `/static/`), and exclude certain file types (like `.html`). Tomcat has very limited url pattern matching available which doesn't let me do this.